### PR TITLE
guide: iOS Onion Browser leaking IP

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -2085,6 +2085,8 @@ Now, you are really done, and you can now surf the web anonymously from your And
 
 ### iOS:
 
+**Disclaimer: Onion Browser, following a 2018 release on iOS, has had IP leaks via WebRTC. It is still the only officially endorsed browser for the Tor network for iOS. Users should exercise caution when using the browser and check for any DNS leaks.**
+
 While the official Tor Browser is not yet available for iOS, there is an alternative called Onion Browser endorsed by the Tor Project[^300].
 
 -   Head over to <https://apps.apple.com/us/app/onion-browser/id519296448>


### PR DESCRIPTION
Disclaimer added: since 2018, it is known to have a leak in `RTCPeerConnection`. This is something that the developers have said cannot be removed and thus, the functionality of the browser still contains this call, and users should be wary of using iOS until it is fixed. We will monitor the situation but it doesn't appear they can patch.

Fixes #138 