### PR TITLE
Move to 1.1.6pre1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+v1.1.6-pre1
+- Update on Tor Browser route due to major changes
+  - Tor Project has condensed their settings and it is no longer
+    necessary to manually configure bridges.
+- Fix out of date options/settings for Tor on Android
+- Small grammar/spelling fixes
+- Removal and fix of some bad links
+- Removal of AnonArchive (down)
+- "How to spot if someone has been searching your stuff" fixed
+- PDF and ODT builds disabled temporarily
+- Update to social links for SEO plugin
+- Link to Qubes tutorial for installing Windows VMs
+- Added link to Arkenfox/user.js
+- Remove unnecessary addons
+
 v1.1.5
 - Various spelling and grammar fixes
 - Fixed several numbering errors in references

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -154,7 +154,7 @@ input:checked + .slider::before {
 			<h1>The Hitchhiker’s Guide to Online Anonymity</h1>
         </a>
         <h2>How I learned to start worrying and love <del>privacy</del> anonymity</h2>
-		<h4 class="project-version">The latest Version is v1.1.5 See the <a href="{{ site.github.changelog_url }}" style="color:#ff4700">changelog.</a></h4>
+		<h4 class="project-version">The latest Version is v1.1.6-pre1 See the <a href="{{ site.github.changelog_url }}" style="color:#ff4700">changelog.</a></h4>
         <section id="downloads">
 			{% if page.url != "/" %}
 				<a href="{{ site.github.home_url }}" class="btn_small">Home</a>

--- a/guide.md
+++ b/guide.md
@@ -2,7 +2,7 @@
 
 (Or "How I learned to start worrying and love ~~privacy~~ anonymity")
 
-Version 1.1.5, June 2022 by Anonymous Planet
+Version 1.1.6pre, August 2022 by Anonymous Planet
 
 **Forever in memory of Lena, 1999-2022**
 

--- a/guide.md
+++ b/guide.md
@@ -2,7 +2,7 @@
 
 (Or "How I learned to start worrying and love ~~privacy~~ anonymity")
 
-Version 1.1.6pre, August 2022 by Anonymous Planet
+Version 1.1.6-pre1, August 2022 by Anonymous Planet
 
 **Forever in memory of Lena, 1999-2022**
 


### PR DESCRIPTION
Move to 1.1.6pre to change the date and reflect that many changes did happen since 1.1.5 while we're working on the changelog and are ready to release? 