### PR TITLE
Fix missing tag for Molly in chart

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -7682,6 +7682,7 @@ Finally, Open-Source apps should always be preferred because they allow third pa
 <td>Good</td>
 <td>No</td>
 <td>Requires phone number. Security hardened fork of Signal client. Security may be delayed for up to a week</td>
+</tr>
 </tbody>
 </table>
 <section class="footnotes footnotes-end-of-document" role="doc-endnotes">


### PR DESCRIPTION
Molly in chart is missing `</tr>` to end the section. It's throwing off the entire guide. Easy fix.

(Thought this should not have been introduced.)

Fixes #215 