### PR TITLE
Add Brainfuck Sec to links

### DIFF
--- a/links.md
+++ b/links.md
@@ -34,3 +34,4 @@ All the links below are listed in alphabetical order:
 - Sci-Hub <https://en.wikipedia.org/wiki/Sci-Hub> <sup>[[Wikiless]](https://wikiless.org/wiki/Sci-Hub)</sup> (see their latest known URL in the main Wikipedia article)
 - Terms of Service, Didn't Read: <https://tosdr.org>
 - Whonix Documentation: <https://www.whonix.org/wiki/Documentation>
+- Brainfuck Sec: <https://brainfucksec.github.io/a-good-privacy-list>


### PR DESCRIPTION
This is a very useful website, but I want to specifically point out their privacy links.